### PR TITLE
Fixed Discord invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
             <a id="navspotweb" href="#spotweb-indexers" class="text-white bg-primary hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition duration-150 ease-in-out">Spotweb Indexers</a>
             <a href="https://rexum.space/p/usenet-provider-deals/" class="text-white hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition duration-150 ease-in-out">Provider Deals</a>
             <a href="https://github.com/PCJones/usenet-guide/" class="text-white hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition duration-150 ease-in-out">Usenet Guide (DE)</a>
-            <a href="https://discord.gg/m6KcBe7mEa" class="text-white hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition duration-150 ease-in-out"><i class="ri-discord-fill discord-icon"></i>
+            <a href="https://discord.gg/src6zcH4rr" class="text-white hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition duration-150 ease-in-out"><i class="ri-discord-fill discord-icon"></i>
        Usenet
 </a>
 


### PR DESCRIPTION
The old Discord invitation was expired, replaced it with the invite from usenet-de guide